### PR TITLE
Cleanup: Remove commented-out endpoint definitions

### DIFF
--- a/EndPoints/EducationEndPoints.cs
+++ b/EndPoints/EducationEndPoints.cs
@@ -105,28 +105,6 @@ namespace CvCodeFirst.EndPoints
                 return Results.Ok("Education updated successfully");
             });
 
-
-
-            //app.MapDelete("/api/educations/{educationId}", async (int educationId, CvApiDBContext dbContext) =>
-            //{
-            //    var (isValidId, idErrors) = InputValidator.ValidateId(educationId);
-            //    if (!isValidId) return Results.BadRequest(idErrors);
-
-            //    var education = await dbContext.Educations.FindAsync(educationId);
-
-
-            //    if (education == null)
-            //    {
-            //        return Results.NotFound("Entered education Id could not be found");
-            //    }
-
-
-            //    dbContext.Educations.Remove(education);
-            //    await dbContext.SaveChangesAsync();
-
-            //    return Results.Ok("Education removed successfully");
-            //});
-
             app.MapDelete("/api/educations/{personId}/{educationId}", async (int personId, int educationId, CvApiDBContext dbContext) =>
             {
                 // Validate IDs

--- a/EndPoints/GitHubReposEndpoints.cs
+++ b/EndPoints/GitHubReposEndpoints.cs
@@ -30,7 +30,6 @@ namespace CvCodeFirst.EndPoints
                 //Validate repo using InputValidator
                 var (validateRepos, validationErrors) = InputValidator.ValidateGitHubRepositories(deserializedRepos!);
 
-                //
                 return Results.Ok(new { Repositories = validateRepos, Errors = validationErrors });
 
             });

--- a/EndPoints/PersonEndpoints.cs
+++ b/EndPoints/PersonEndpoints.cs
@@ -93,65 +93,7 @@ namespace CvCodeFirst.EndPoints
                 return Results.Created($"/api/persons/{person.ID}", result);
             });
 
-            //app.MapPost("/api/persons", async (CreatePersonWithDetailsDto dto, CvApiDBContext dbContext) =>
-            //{
-            //    var (isValid, errors) = InputValidator.Validate(dto);
-            //    if (!isValid) return Results.BadRequest(errors);
-
-            //    var person = new Person
-            //    {
-            //        FullName = dto.FullName,
-            //        Email = dto.Email,
-            //        Phone = dto.Phone,
-            //        Description = dto.Description,
-            //        Educations = dto.Educations.Select(e => new Education
-            //        {
-            //            School = e.School,
-            //            Degree = e.Degree,
-            //            StartDate = e.StartDate,
-            //            EndDate = e.EndDate
-            //        }).ToList(),
-            //        WorkExperiences = dto.WorkExperiences.Select(w => new WorkExperience 
-            //        { 
-            //            JobTitle = w.JobTitle,
-            //            Company = w.Company,
-            //            Description = w.Description,
-            //            StartDate = w.StartDate,
-            //            EndDate = w.EndDate
-            //        }).ToList()
-            //    };
-
-            //    dbContext.Person.Add(person);
-            //    await dbContext.SaveChangesAsync();
-
-            //    var result = new PersonDetailDto
-            //    {
-            //        FullName = person.FullName,
-            //        Email = person.Email,
-            //        Phone = person.Phone,
-            //        Description = person.Description,
-            //        Educations = person.Educations.Select(e => new EducationDTO
-            //        {
-            //            EducationID = e.EducationID,
-            //            School = e.School,
-            //            Degree = e.Degree,
-            //            StartDate = e.StartDate,
-            //            EndDate = e.EndDate
-            //        }).ToList(),
-            //        WorkExperiences = person.WorkExperiences.Select(w => new WorkExperienceDTO
-            //        {
-            //            WorkExperienceID =w.WorkExperienceID,
-            //            JobTitle = w.JobTitle,
-            //            Company = w.Company,
-            //            Description = w.Description,
-            //            StartDate = w.StartDate,
-            //            EndDate = w.EndDate
-            //        }).ToList()
-            //    };
-
-            //    return Results.Created($"/api/persons/{person.ID}", result);
-
-            //});
+           
 
             //Get the people in the database
             app.MapGet("/api/persons", async (CvApiDBContext dbContext) =>

--- a/EndPoints/WorkExperienceEndPoints.cs
+++ b/EndPoints/WorkExperienceEndPoints.cs
@@ -51,29 +51,6 @@ namespace CvCodeFirst.EndPoints
             });
 
 
-            //app.MapPost("api/persons/{personId}/workexperiences", async (int personId,WorkExperienceDTO dto, CvApiDBContext dbContext) =>
-            //{
-            //    var (isValid, errors) = InputValidator.Validate(dto);
-            //    if (!isValid) return Results.BadRequest(errors);
-
-            //    var (personExists, personErrors) = await InputValidator.ValidatePersonExistsAsync(personId, dbContext);
-            //    if (!personExists) return Results.BadRequest(personErrors);
-
-            //    var experience = new WorkExperience
-            //    {
-            //        JobTitle = dto.JobTitle,
-            //        Company = dto.Company,
-            //        Description = dto.Description,
-            //        StartDate = dto.StartDate,
-            //        EndDate = dto.EndDate,
-            //        PersonID = personId
-            //    };
-
-            //    dbContext.WorkExperiences.Add(experience);
-            //    await dbContext.SaveChangesAsync();
-
-            //    return Results.Created($"/api/workexperiences/{experience.WorkExperienceID}", experience);
-            //});
 
             //Get/Retrieve work experience 
             app.MapGet("/api/person/{personId}/workexperiences", async (int personId, CvApiDBContext dbContext) =>


### PR DESCRIPTION
This commit removes several commented-out endpoint definitions in the `EducationEndPoints.cs`, `GitHubReposEndpoints.cs`, `PersonEndpoints.cs`, and `WorkExperienceEndPoints.cs` files. These changes streamline the codebase and focus on active endpoint definitions, such as `MapDelete` for education records and `MapGet` for retrieving persons and work experiences.